### PR TITLE
BugFix: Start powershell as normal or admin user

### DIFF
--- a/pwsh-scripts/pwsh-start.ps1
+++ b/pwsh-scripts/pwsh-start.ps1
@@ -13,9 +13,6 @@ $Account = "$env:UserDomain\$env:Username"
 # Start dockerd service on Windows
 Start-Service docker
 
-# Start WSL distro
-Start-Job -Name rekcod-wsl -ScriptBlock{ wsl -d rekcod-wsl }
-
 # Allow non-admin users to use Docker
 $Info = New-Object "System.IO.DirectoryInfo" -ArgumentList "\\.\pipe\docker_engine"
 $AccessControl = $Info.GetAccessControl()

--- a/rekcod-start.ps1
+++ b/rekcod-start.ps1
@@ -14,4 +14,7 @@ Write-Host "Starting Docker for Linux..." -ForegroundColor Yellow
 # Call script
 powershell -File ${RekcodInstallationPath}\pwsh-scripts\pwsh-start.ps1
 
+# Start WSL distro
+Start-Job -Name rekcod-wsl -ScriptBlock{ wsl -d rekcod-wsl }
+
 Write-Host "Docker is up and ready! Happy coding!" -ForegroundColor Green


### PR DESCRIPTION
The last approach was that `rekcod-start.ps1` will call `pwsh-start.ps1` and it will execute some actions, as starting a job with WSL in the background.

The behavior was that the Start-Job wasn´t executed so WSl could not be started, so I just moved it to the `rekcod-start.ps1` script so it will have enough time to execute and start the WSL backend